### PR TITLE
Add that cls option can be combined with html in feature info

### DIFF
--- a/content/layers.md
+++ b/content/layers.md
@@ -566,7 +566,7 @@ Attribute options | Description
 `target` | used along with url to open link in an iframe in a modal window. Can be set to modal for normal size or modal-full. Optional.
 `img` | attribute containing url to an image. The image will be embedded. Optional.
 `cls` | css class name for custom styling. Optional.
-`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The html option can be combined with `cls`, but none of the other options. Optional.
+`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The html option can't be combined with any of the other options. Optional.
 
 #### Example defining layer attributes
 
@@ -586,8 +586,7 @@ Attribute options | Description
       "urlSuffix":".html"
     },
     {
-      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>",
-	  "cls": "o-custom-class"
+      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>"
     }
   ]
 }

--- a/content/layers.md
+++ b/content/layers.md
@@ -566,7 +566,7 @@ Attribute options | Description
 `target` | used along with url to open link in an iframe in a modal window. Can be set to modal for normal size or modal-full. Optional.
 `img` | attribute containing url to an image. The image will be embedded. Optional.
 `cls` | css class name for custom styling. Optional.
-`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The html option can't be combined with any of the other options. Optional.
+`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The html option can be combined with `cls`, but none of the other options. Optional.
 
 #### Example defining layer attributes
 
@@ -586,7 +586,8 @@ Attribute options | Description
       "urlSuffix":".html"
     },
     {
-      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>"
+      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>",
+	  "cls": "o-custom-class"
     }
   ]
 }

--- a/content/layers.md
+++ b/content/layers.md
@@ -586,7 +586,8 @@ Attribute options | Description
       "urlSuffix":".html"
     },
     {
-      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>"
+      "html": "<p>For more information contact {{CONTACT}} at {{PHONE}}</p>",
+      "cls": "o-custom-class-name"
     }
   ]
 }

--- a/content/layers.md
+++ b/content/layers.md
@@ -566,7 +566,7 @@ Attribute options | Description
 `target` | used along with url to open link in an iframe in a modal window. Can be set to modal for normal size or modal-full. Optional.
 `img` | attribute containing url to an image. The image will be embedded. Optional.
 `cls` | css class name for custom styling. Optional.
-`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The html option can't be combined with any of the other options. Optional.
+`html` | custom html. Attributes can be referenced be placing the attribute name within double curly brackets.  It also possible in a similar way to insert functions, for example getCenter which is written as `{{@center}}`. Arguments can be added, for example `{{@center(EPSG:4326,reverse)}}` to get the center coordinates in EPSG:4326 with reversed coordinates (or `{{@center(EPSG:4326,default)}}` to maintain the axis orientation after transformation). The `html` option can't be combined with any of the other options, except for `cls`. Optional.
 
 #### Example defining layer attributes
 


### PR DESCRIPTION
Fixes #86.

Changed the wording
>The html option can't be combined with any of the other options.

to
>The `html` option can't be combined with any of the other options, except for `cls`.

Also added the cls parameter to the html example to make it more obvious how it can be used.